### PR TITLE
fix accessing location coordinates

### DIFF
--- a/lib/widgets/place_picker.dart
+++ b/lib/widgets/place_picker.dart
@@ -275,7 +275,7 @@ class PlacePickerState extends State<PlacePicker> {
         throw Error();
       }
 
-      final location = responseJson['geometry']['location'];
+      final location = responseJson['result']['geometry']['location'];
       moveToLocation(LatLng(location['lat'], location['lng']));
     } catch (e) {
       print(e);


### PR DESCRIPTION
The `geometry` key is within `result` which was throwing an error currently. This should fix it and should move the camera to the selected location.