### PR TITLE
Fix TextTheme error

### DIFF
--- a/lib/widgets/rich_suggestion.dart
+++ b/lib/widgets/rich_suggestion.dart
@@ -24,18 +24,23 @@ class RichSuggestion extends StatelessWidget {
     final List<TextSpan> result = [];
     final style = TextStyle(color: Colors.grey, fontSize: 15);
 
-    final startText = autoCompleteItem.text!.substring(0, autoCompleteItem.offset);
+    final startText =
+        autoCompleteItem.text!.substring(0, autoCompleteItem.offset);
     if (startText.isNotEmpty) {
       result.add(TextSpan(text: startText, style: style));
     }
 
-    final boldText =
-        autoCompleteItem.text!.substring(autoCompleteItem.offset!, autoCompleteItem.offset! + autoCompleteItem.length!);
+    final boldText = autoCompleteItem.text!.substring(autoCompleteItem.offset!,
+        autoCompleteItem.offset! + autoCompleteItem.length!);
     result.add(
-      TextSpan(text: boldText, style: style.copyWith(color: Theme.of(context).textTheme.body1!.color)),
+      TextSpan(
+          text: boldText,
+          style: style.copyWith(
+              color: Theme.of(context).textTheme.bodyText1!.color)),
     );
 
-    final remainingText = autoCompleteItem.text!.substring(autoCompleteItem.offset! + autoCompleteItem.length!);
+    final remainingText = autoCompleteItem.text!
+        .substring(autoCompleteItem.offset! + autoCompleteItem.length!);
     result.add(TextSpan(text: remainingText, style: style));
 
     return result;

--- a/lib/widgets/search_input.dart
+++ b/lib/widgets/search_input.dart
@@ -57,11 +57,13 @@ class SearchInputState extends State<SearchInput> {
       padding: EdgeInsets.symmetric(horizontal: 8),
       child: Row(
         children: <Widget>[
-          Icon(Icons.search, color: Theme.of(context).textTheme.body1!.color),
+          Icon(Icons.search,
+              color: Theme.of(context).textTheme.bodyText1!.color),
           SizedBox(width: 8),
           Expanded(
             child: TextField(
-              decoration: InputDecoration(hintText: "Search place", border: InputBorder.none),
+              decoration: InputDecoration(
+                  hintText: "Search place", border: InputBorder.none),
               controller: this.editController,
               onChanged: (value) {
                 setState(() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -174,7 +174,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -216,7 +216,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
On dart 2.4.0 or above its gives error because of Theme.of(context).textTheme.body1 doesn't exists anymore. Just changed to Theme.of(context).textTheme.bodyText1.