### PR TITLE
Theme Fix

### DIFF
--- a/lib/widgets/rich_suggestion.dart
+++ b/lib/widgets/rich_suggestion.dart
@@ -32,7 +32,7 @@ class RichSuggestion extends StatelessWidget {
     final boldText =
         autoCompleteItem.text.substring(autoCompleteItem.offset, autoCompleteItem.offset + autoCompleteItem.length);
     result.add(
-      TextSpan(text: boldText, style: style.copyWith(color: Theme.of(context).textTheme.body1.color)),
+      TextSpan(text: boldText, style: style.copyWith(color: Theme.of(context).textTheme.bodyText1.color)),
     );
 
     final remainingText = autoCompleteItem.text.substring(autoCompleteItem.offset + autoCompleteItem.length);

--- a/lib/widgets/search_input.dart
+++ b/lib/widgets/search_input.dart
@@ -57,7 +57,7 @@ class SearchInputState extends State<SearchInput> {
       padding: EdgeInsets.symmetric(horizontal: 8),
       child: Row(
         children: <Widget>[
-          Icon(Icons.search, color: Theme.of(context).textTheme.body1.color),
+          Icon(Icons.search, color: Theme.of(context).textTheme.bodyText1.color),
           SizedBox(width: 8),
           Expanded(
             child: TextField(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.0
-  google_maps_flutter: ^1.0.5
+  google_maps_flutter: ^2.1.1
   location: ^2.3.5
 
 dev_dependencies:


### PR DESCRIPTION
After flutter v2.2, body1 is deprecated in favor of bodyText1. Build error is thrown that is resolved by a simple substitution.